### PR TITLE
[demo] bring in repokitteh's assign module

### DIFF
--- a/repokitteh.sky
+++ b/repokitteh.sky
@@ -1,0 +1,1 @@
+use("github.com/softkitteh/repokitteh-modules/assign.sky")

--- a/repokitteh.sky
+++ b/repokitteh.sky
@@ -1,1 +1,5 @@
 use("github.com/softkitteh/repokitteh-modules/assign.sky")
+
+def on_issue_comment(comment):
+  if comment == "/error":
+    error("oh noes!")


### PR DESCRIPTION
*this PR is for demo purposes only and should not be merged. a replacement pr is now at https://github.com/envoyproxy/envoybot/pull/3.*

this is an example of how to bring in a ready-made repokitteh module. modules can also be coded inside this repo as well.

i'm going to invest heavily in docs very soon, this is just an example to show @cmluciano, @htuch and @mattklein123.

note that even while this change is not merged, it is still possible to test this in the pr itself. this might pose a security threat, or a way to subvert proper procedures so we might want to enable this to specific users, such as users which are members of a certain group or just a configurable whitelist.

also in the future i'm going to implement a security model where in the `use` clause one can specify what capabilities to allow the module. also the `use` clause can accomodate specifying a sha of the module to use.
